### PR TITLE
Fixed bug that prohibited Admin users from creating new blogging category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ config/mail.yml
 *~
 db/*.sqlite*
 db/schema.rb
+db/db_development
+db/db_test
 .*.swp
 .*.swo
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -57,4 +57,6 @@ group :development, :test do
   gem 'cucumber-rails-training-wheels'
   gem 'database_cleaner'
   gem 'capybara'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -59,4 +59,5 @@ group :development, :test do
   gem 'capybara'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'pry-rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -59,5 +59,4 @@ group :development, :test do
   gem 'capybara'
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'pry-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
     abstract (1.0.0)
@@ -205,3 +205,6 @@ DEPENDENCIES
   thin
   uuidtools (~> 2.1.1)
   webrat
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,11 @@ GEM
     addressable (2.3.2)
     archive-tar-minitar (0.5.2)
     arel (2.0.10)
+    better_errors (0.0.8)
+      coderay
+      erubis
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bluecloth (2.2.0)
     builder (2.1.2)
     capybara (1.1.2)
@@ -60,6 +65,7 @@ GEM
       cucumber-rails (>= 1.1.1)
     daemons (1.1.9)
     database_cleaner (0.8.0)
+    debug_inspector (0.0.2)
     diff-lcs (1.1.3)
     erubis (2.6.6)
       abstract (>= 1.0.0)
@@ -179,6 +185,8 @@ DEPENDENCIES
   acts_as_list
   acts_as_tree_rails3
   addressable (~> 2.1)
+  better_errors
+  binding_of_caller
   bluecloth (~> 2.1)
   capybara
   coderay (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     childprocess (0.3.5)
       ffi (~> 1.0, >= 1.0.6)
     coderay (0.9.8)
-    columnize (0.3.6)
+    columnize (0.9.0)
     cucumber (1.2.1)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -66,6 +66,12 @@ GEM
     daemons (1.1.9)
     database_cleaner (0.8.0)
     debug_inspector (0.0.2)
+    debugger (1.6.8)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.8)
     diff-lcs (1.1.3)
     erubis (2.6.6)
       abstract (>= 1.0.0)
@@ -93,8 +99,6 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    method_source (0.6.7)
-      ruby_parser (>= 2.3.1)
     mime-types (1.19)
     mini_magick (1.3.3)
       subexec (~> 0.0.4)
@@ -102,13 +106,6 @@ GEM
     nokogiri (1.5.5)
     pg (0.14.1)
     polyglot (0.3.3)
-    pry (0.9.7.4)
-      coderay (~> 0.9.8)
-      method_source (~> 0.6.7)
-      ruby_parser (>= 2.3.1)
-      slop (~> 2.1.0)
-    pry-rails (0.2.0)
-      pry
     rack (1.2.5)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -156,8 +153,6 @@ GEM
       ruby-debug-base19 (>= 0.11.19)
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
-    ruby_parser (3.8.1)
-      sexp_processor (~> 4.1)
     rubypants (0.2.0)
     rubyzip (0.9.9)
     selenium-webdriver (2.25.0)
@@ -165,12 +160,10 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    sexp_processor (4.7.0)
     simplecov (0.6.4)
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
-    slop (2.1.0)
     sqlite3 (1.3.6)
     subexec (0.0.4)
     thin (1.5.0)
@@ -207,6 +200,7 @@ DEPENDENCIES
   cucumber-rails
   cucumber-rails-training-wheels
   database_cleaner
+  debugger
   factory_girl (~> 2.2)
   flickraw-cached
   htmlentities
@@ -214,7 +208,6 @@ DEPENDENCIES
   kaminari
   mini_magick (~> 1.3.3)
   pg
-  pry-rails
   rails (~> 3.0.10)
   rake (~> 0.9.2)
   recaptcha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.6.7)
+      ruby_parser (>= 2.3.1)
     mime-types (1.19)
     mini_magick (1.3.3)
       subexec (~> 0.0.4)
@@ -100,6 +102,13 @@ GEM
     nokogiri (1.5.5)
     pg (0.14.1)
     polyglot (0.3.3)
+    pry (0.9.7.4)
+      coderay (~> 0.9.8)
+      method_source (~> 0.6.7)
+      ruby_parser (>= 2.3.1)
+      slop (~> 2.1.0)
+    pry-rails (0.2.0)
+      pry
     rack (1.2.5)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -147,6 +156,8 @@ GEM
       ruby-debug-base19 (>= 0.11.19)
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
+    ruby_parser (3.8.1)
+      sexp_processor (~> 4.1)
     rubypants (0.2.0)
     rubyzip (0.9.9)
     selenium-webdriver (2.25.0)
@@ -154,10 +165,12 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
+    sexp_processor (4.7.0)
     simplecov (0.6.4)
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
+    slop (2.1.0)
     sqlite3 (1.3.6)
     subexec (0.0.4)
     thin (1.5.0)
@@ -201,6 +214,7 @@ DEPENDENCIES
   kaminari
   mini_magick (~> 1.3.3)
   pg
+  pry-rails
   rails (~> 3.0.10)
   rake (~> 0.9.2)
   recaptcha

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -4,10 +4,10 @@ class Admin::CategoriesController < Admin::BaseController
   def index; redirect_to :action => 'new' ; end
   def edit; new_or_edit;  end
 
-  def new 
+  def new
     respond_to do |format|
       format.html { new_or_edit }
-      format.js { 
+      format.js {
         @category = Category.new
       }
     end
@@ -23,14 +23,23 @@ class Admin::CategoriesController < Admin::BaseController
 
   private
 
+  # not sure if this is necessary
+  # def category_params
+  #   params.permit(category:[:id])
+  # end
+
   def new_or_edit
     @categories = Category.find(:all)
+    # params[:id] is nil currently. Do we need a private save method?
+    # the @category in the above 'new' method is not getting passed to here,
+    # so there are no params.
     @category = Category.find(params[:id])
+    # what does params[:category] do?
     @category.attributes = params[:category]
     if request.post?
       respond_to do |format|
         format.html { save_category }
-        format.js do 
+        format.js do
           @category.save
           @article = Article.new
           @article.categories << @category

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -23,18 +23,13 @@ class Admin::CategoriesController < Admin::BaseController
 
   private
 
-  # not sure if this is necessary
-  # def category_params
-  #   params.permit(category:[:id])
-  # end
-
   def new_or_edit
     @categories = Category.find(:all)
-    # params[:id] is nil currently. Do we need a private save method?
-    # the @category in the above 'new' method is not getting passed to here,
-    # so there are no params.
-    @category = Category.find(params[:id])
-    # what does params[:category] do?
+    if params[:id] == nil
+      @category = Category.new
+    else
+      @category = Category.find_by_id(params[:id])
+    end
     @category.attributes = params[:category]
     if request.post?
       respond_to do |format|

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,9 +2,4 @@ class CategoriesController < GroupingController
   # index - inherited
   # show - inherited
 
-  def new
-    
-  end
-
-
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,10 @@
 class CategoriesController < GroupingController
   # index - inherited
   # show - inherited
+
+  def new
+    
+  end
+
+
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -9,5 +9,5 @@
 <div class='dashboard'>
   <%= render "inbound" %>
   <%= render "posts" %>
-  <%= render "typo_dev" %>  
+  <%= render "typo_dev" %>
 </div>

--- a/features/create_categories.feature
+++ b/features/create_categories.feature
@@ -7,6 +7,31 @@ Feature: Create Categories
     Given the blog is set up
     And I am logged into the admin panel
 
-  Scenario: Successfully create categories
+  Scenario: Successfully visit categories page
     When I follow "Categories"
     Then I should see "Categories"
+
+  Scenario: Create Valid Category
+    When I follow "Categories"
+    When I fill in "Name" with "applesauce"
+    And I fill in "Keywords" with "apples"
+    And I fill in "Permalink" with "www.link.com"
+    And I fill in "Description" with "A compelling description"
+    And  I press "Save"
+    Then I should see "Category was successfully saved."
+
+    Scenario: Edit a Category
+      When I go to the edit page for "applesauce"
+      And I fill in "Description" with "Tasty"
+      And I press "Save"
+      And I should see "Category was successfully saved."
+
+      Scenario: Cancel editing a category
+        When I go to the edit page for "applesauce"
+        And I fill in "Description" with "Tasty"
+        And I press "Cancel"
+        Then I should be on "Categories"
+
+    Scenario: Delete a Category
+      When I go to the delete page for "applesauce"
+      Then I should see "Are you sure you want to destroy this category"

--- a/features/create_categories.feature
+++ b/features/create_categories.feature
@@ -1,0 +1,12 @@
+Feature: Create Categories
+  As a blog administrator
+  In order to categorize different blog topics
+  I want to be add and manage categories to my blog articles
+
+  Background:
+    Given the blog is set up
+    And I am logged into the admin panel
+
+  Scenario: Successfully create categories
+    When I follow "Categories"
+    Then I should see "Categories"

--- a/features/create_categories.feature
+++ b/features/create_categories.feature
@@ -24,7 +24,8 @@ Feature: Create Categories
       When I go to the edit page for "applesauce"
       And I fill in "Description" with "Tasty"
       And I press "Save"
-      And I should see "Category was successfully saved."
+      Then I should see "Category was successfully saved."
+      Then the "description" field for "applesauce" should be "tasty".
 
     Scenario: Cancel editing a category
       When I go to the edit page for "applesauce"

--- a/features/create_categories.feature
+++ b/features/create_categories.feature
@@ -7,18 +7,18 @@ Feature: Create Categories
     Given the blog is set up
     And I am logged into the admin panel
 
-  Scenario: Successfully visit categories page
-    When I follow "Categories"
-    Then I should see "Categories"
+    Scenario: Successfully visit categories page
+      When I follow "Categories"
+      Then I should see "Categories"
 
-  Scenario: Create Valid Category
-    When I follow "Categories"
-    When I fill in "Name" with "applesauce"
-    And I fill in "Keywords" with "apples"
-    And I fill in "Permalink" with "www.link.com"
-    And I fill in "Description" with "A compelling description"
-    And  I press "Save"
-    Then I should see "Category was successfully saved."
+    Scenario: Create Valid Category
+      When I follow "Categories"
+      When I fill in "Name" with "applesauce"
+      And I fill in "Keywords" with "apples"
+      And I fill in "Permalink" with "www.link.com"
+      And I fill in "Description" with "A compelling description"
+      And  I press "Save"
+      Then I should see "Category was successfully saved."
 
     Scenario: Edit a Category
       When I go to the edit page for "applesauce"
@@ -26,12 +26,8 @@ Feature: Create Categories
       And I press "Save"
       And I should see "Category was successfully saved."
 
-      Scenario: Cancel editing a category
-        When I go to the edit page for "applesauce"
-        And I fill in "Description" with "Tasty"
-        And I press "Cancel"
-        Then I should be on "Categories"
-
-    Scenario: Delete a Category
-      When I go to the delete page for "applesauce"
-      Then I should see "Are you sure you want to destroy this category"
+    Scenario: Cancel editing a category
+      When I go to the edit page for "applesauce"
+      And I fill in "Description" with "Tasty"
+      And I press "Cancel"
+      Then I should be on "Categories"

--- a/features/merge_articles.feature
+++ b/features/merge_articles.feature
@@ -1,0 +1,11 @@
+Feature: Merge articles
+  As an admin, I can merge two articles together into one article.
+  As a user, I cannot merge articles.
+
+  Background:
+    Given the blog is set up
+    And I am logged in as a user
+
+  Scenario: I cannot see the merge
+    Given I am on the new article page
+    Then I should not see "Merge Articles"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -55,6 +55,25 @@ And /^I am logged into the admin panel$/ do
   end
 end
 
+Given /^I am logged in as a user$/ do
+  User.create!({:login => 'trowbrsa',
+                :password => 'supersecret',
+                :email => 'trowbrsa@email.com',
+                :profile_id => 2,
+                :name => 'Sarah',
+                :state => 'active'})
+  visit '/accounts/logout'
+  visit '/accounts/login'
+  fill_in 'user_login', :with => 'trowbrsa'
+  fill_in 'user_password', :with => 'supersecret'
+  click_button 'Login'
+  if page.respond_to? :should
+    page.should have_content('Login successful')
+  else
+    assert page.has_content?('Login successful')
+  end
+end
+
 # Single-line step scoper
 When /^(.*) within (.*[^:])$/ do |step, parent|
   with_scope(parent) { When step }
@@ -250,7 +269,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should not be checked$/ do |label
     end
   end
 end
- 
+
 Then /^(?:|I )should be on (.+)$/ do |page_name|
   current_path = URI.parse(current_url).path
   if current_path.respond_to? :should
@@ -264,8 +283,8 @@ Then /^(?:|I )should have the following query string:$/ do |expected_pairs|
   query = URI.parse(current_url).query
   actual_params = query ? CGI.parse(query) : {}
   expected_params = {}
-  expected_pairs.rows_hash.each_pair{|k,v| expected_params[k] = v.split(',')} 
-  
+  expected_pairs.rows_hash.each_pair{|k,v| expected_params[k] = v.split(',')}
+
   if actual_params.respond_to? :should
     actual_params.should == expected_params
   else

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -18,6 +18,9 @@ module NavigationHelpers
     when /^the new article page$/
       '/admin/content/new'
 
+    when /^the edit page for "(.*)"$/
+      admin_categories_path(Category.find_by_name($1))
+
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:
     #

--- a/public/javascripts/ckeditor/config.bak
+++ b/public/javascripts/ckeditor/config.bak
@@ -8,7 +8,7 @@ CKEDITOR.editorConfig = function( config )
   config.PreserveSessionOnFileBrowser = true;
   // Define changes to default configuration here. For example:
  	//config.language = '';
-  config.uiColor = '#E0ECFF';
+  config.uiColor = '#eee';
 	config.toolbar = 'Basic';
 	config.entities_greek = false;
 	config.entities_latin = false;

--- a/public/javascripts/ckeditor/config.js
+++ b/public/javascripts/ckeditor/config.js
@@ -8,7 +8,7 @@ CKEDITOR.editorConfig = function( config )
   config.PreserveSessionOnFileBrowser = true;
   // Define changes to default configuration here. For example:
  	//config.language = '';
-  config.uiColor = '#E0ECFF';
+  config.uiColor = '#eee';
 	config.toolbar = 'Basic';
 	config.entities_greek = false;
 	config.entities_latin = false;

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -16,6 +16,11 @@ describe Admin::CategoriesController do
     expect(response.status).to eq 200
   end
 
+  it "renders the correct template" do
+    get :new
+    expect(response).to render_template :new
+  end
+
   it "test_index" do
    get :index
    assert_response :redirect, :action => 'index'

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -13,7 +13,7 @@ describe Admin::CategoriesController do
 
   it "test_index" do
     get :index
-    assert_response :redirect, :action => 'index'
+    assert_response :redirect, :action => 'new'
   end
 
   describe "test_edit" do
@@ -48,7 +48,7 @@ describe Admin::CategoriesController do
 
     it 'should render destroy template' do
       assert_response :success
-      assert_template 'destroy'      
+      assert_template 'destroy'
     end
   end
 
@@ -62,5 +62,5 @@ describe Admin::CategoriesController do
 
     assert_raise(ActiveRecord::RecordNotFound) { Category.find(test_id) }
   end
-  
+
 end

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -11,9 +11,14 @@ describe Admin::CategoriesController do
     request.session = { :user => henri.id }
   end
 
-  it "test_index" do
+  it "successfully loads" do
     get :index
-    assert_response :redirect, :action => 'new'
+    expect(response.status).to eq 200
+  end
+
+  it "test_index" do
+   get :index
+   assert_response :redirect, :action => 'index'
   end
 
   describe "test_edit" do

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -12,7 +12,7 @@ describe Admin::CategoriesController do
   end
 
   it "successfully loads" do
-    get :index
+    get :new
     expect(response.status).to eq 200
   end
 

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -28,11 +28,7 @@ describe CategoriesController, "/index" do
 
   describe "if :index template exists" do
     it "should render :index" do
-      pending "Stubbing #template_exists is not enough to fool Rails"
-      controller.stub!(:template_exists?) \
-        .and_return(true)
-
-      do_get
+      get 'index'
       response.should render_template(:index)
     end
   end
@@ -73,14 +69,14 @@ describe CategoriesController, '#show' do
     do_get
     response.should render_template('articles/index')
   end
-  
+
   it 'should render personal when template exists' do
     pending "Stubbing #template_exists is not enough to fool Rails"
     controller.stub!(:template_exists?) \
       .and_return(true)
     do_get
     response.should render_template('personal')
-  end  
+  end
 
   it 'should show only published articles' do
     do_get
@@ -94,7 +90,7 @@ describe CategoriesController, '#show' do
 
   describe "when rendered" do
     render_views
-  
+
     it 'should have a canonical URL' do
       do_get
       response.should have_selector('head>link[href="http://myblog.net/category/personal/"]')
@@ -154,7 +150,7 @@ describe CategoriesController, "password protected article" do
 
     assert_tag :tag => "input",
       :attributes => { :id => "article_password" }
-  end  
+  end
 end
 
 describe CategoriesController, "SEO Options" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.use_instantiated_fixtures  = false
   config.fixture_path = "#{::Rails.root}/test/fixtures"
+  config.alias_example_to :fit, focused: true
+  config.filter_run focused: true
+  config.run_all_when_everything_filtered = true
 
   config.before(:each) do
     Localization.lang = :default
@@ -214,4 +217,3 @@ module Webrat #:nodoc:
     end
   end
 end
-


### PR DESCRIPTION
There was a bug that did not allow admin users to create new blogging categories. This was because view for adding a new category is managed by the 'new_or_edit' function in the admin categories controller.  Previously, this method required categories to have an ID. Since new categories will not have an id until they are saved later on in the method, the page was erroring out. I updated the method by creating a wrapper for new categories that are instantiated. Let me know if you have any questions. Thanks! 
